### PR TITLE
Add python3 compatibility

### DIFF
--- a/examples/output_leodis.py
+++ b/examples/output_leodis.py
@@ -25,13 +25,13 @@ for tree in L.forest:
         L.forest[tree].trunk.output_cluster_table(outputfileascii, format="ascii", extended=dataarr, leodis_cols=leodis_cols)
         L.forest[tree].trunk.output_cluster_table(outputfilefits, format="fits", extended=dataarr, leodis_cols=leodis_cols, headings=headings)
         t = Table.read(outputfilefits)
-        print t
-        print ""
+        print(t)
+        print("")
     else:
         outputfileascii = outputdirectoryascii+'leodis_hierarchical_tree_'+str(tree)+'.dat'
         outputfilefits = outputdirectoryfits+'leodis_hierarchical_tree_'+str(tree)+'.fits'
         L.forest[tree].trunk.output_cluster_table(outputfileascii, format="ascii", extended=dataarr, leodis_cols=leodis_cols)
         L.forest[tree].trunk.output_cluster_table(outputfilefits, format="fits", extended=dataarr, leodis_cols=leodis_cols, headings=headings)
         t = Table.read(outputfilefits)
-        print t
-        print ""
+        print(t)
+        print("")

--- a/leodis/__init__.py
+++ b/leodis/__init__.py
@@ -12,4 +12,4 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
-    from leodis import Leodis
+    from .leodis import Leodis

--- a/leodis/leodis.py
+++ b/leodis/leodis.py
@@ -9,9 +9,9 @@ CONTACT: j.d.henshaw@ljmu.ac.uk
 import numpy as np
 import itertools
 import sys
-import leodis_io
 import time
-from progressbar import AnimatedProgressBar
+from . import leodis_io
+from .progressbar import AnimatedProgressBar
 from scipy.spatial import distance
 from scipy.spatial import cKDTree
 from .cluster_definition import Cluster
@@ -20,6 +20,13 @@ from .cluster_definition import merge_data
 from .cluster_definition import form_a_branch
 from .tree_definition import Tree
 from math import log10, floor
+
+# add Python 2 xrange compatibility, to be removed
+# later when we switch to numpy loops
+if sys.version_info.major >= 3:
+    range = range
+else:
+    range = xrange
 
 class Leodis(object):
 
@@ -153,7 +160,7 @@ class Leodis(object):
 
         # Cycle through the unassigned array
         starthierarchy = time.time()
-        for i in xrange(0, unassigned_array_length):
+        for i in range(0, unassigned_array_length):
 
             if verbose and (count % 1 == 0):
                 progress_bar + 1
@@ -228,8 +235,8 @@ class Leodis(object):
         if verbose:
             progress_bar.progress = 100
             progress_bar.show_progress()
-            print ''
-            print ''
+            print('')
+            print('')
 
         endhierarchy = time.time()-starthierarchy
 
@@ -303,8 +310,8 @@ class Leodis(object):
             if verbose:
                 progress_bar.progress = 100  # Done
                 progress_bar.show_progress()
-                print ''
-                print ''
+                print('')
+                print('')
 
             endrelax = time.time()-startrelax
 
@@ -324,13 +331,13 @@ class Leodis(object):
         end = time.time()-start
 
         if verbose:
-            print('leodis took {0:0.1f} seconds for completion.').format(end)
-            print('Primary clustering took {0:0.1f} seconds for completion.').format(endhierarchy)
+            print('leodis took {0:0.1f} seconds for completion.'.format(end))
+            print('Primary clustering took {0:0.1f} seconds for completion.'.format(endhierarchy))
             if relaxcond==True:
-                print('Secondary clustering took {0:0.1f} seconds for completion.').format(endrelax)
-            print ''
-            print('leodis found a total of {0} clusters').format(len(self.clusters))
-            print ''
+                print('Secondary clustering took {0:0.1f} seconds for completion.'.format(endrelax))
+            print('')
+            print('leodis found a total of {0} clusters'.format(len(self.clusters)))
+            print('')
         return self
 
     def save_to(self, filename):
@@ -474,14 +481,14 @@ def get_links(self, index, tree, n_jobs, re=False):
         idx = init_query(tree, np.array([coords[0,0:2]]), self.cluster_criteria[0], n_jobs)
         link = np.ones(len(idx), dtype=bool)
         if len(self.cluster_criteria) != 1:
-            for i in xrange(len(self.cluster_criteria)-1):
+            for i in range(len(self.cluster_criteria)-1):
                 link = further_query(link, coords[0,4+i], self.unassigned_data[4+i,idx], self.cluster_criteria[1+i])
         link = idx[np.where(np.array(link)==True)]
     else:
         idx = init_query(tree, np.array([coords[0,0:3]]), self.cluster_criteria[0], n_jobs)
         link = np.ones(len(idx), dtype=bool)
         if len(self.cluster_criteria) != 1:
-            for i in xrange(len(self.cluster_criteria)-1):
+            for i in range(len(self.cluster_criteria)-1):
                 link = further_query(link, coords[0,5+i], self.unassigned_data[5+i,idx], self.cluster_criteria[1+i])
         link = idx[np.where(np.array(link)==True)]
 
@@ -589,7 +596,7 @@ def find_linked_clusters_single_antecessor(self, cluster, linked_clusters):
 
     # Establish the min/max values of all linked clusters and arrange in
     # descending order
-    floor = [link.merge_level for link in linked_clusters]
+    floor = [link.merge_level if link.merge_level else -np.inf for link in linked_clusters]
     ceiling = [link.descendants[0].merge_level if link.branch_cluster else np.inf for link in linked_clusters ]
     sort_idx = np.argsort(floor)[::-1]
     linked_clusters = [linked_clusters[idx] for idx in sort_idx ]
@@ -626,7 +633,7 @@ def find_linked_clusters_single_antecessor(self, cluster, linked_clusters):
                 while _linked_cluster.antecedent is not None:
                     _linked_cluster = _linked_cluster.antecedent
                     if _linked_cluster.antecedent == None:
-                        _floor = None
+                        _floor = -np.inf
                         _ceiling = _linked_cluster.descendants[0].merge_level
                         if (cluster_floor >= _floor) & (cluster_ceiling <= _ceiling):
                             slot[j] = True
@@ -1349,7 +1356,7 @@ def update_clusters(self):
     bud_list = []
     bud_indices = []
 
-    for cluster_index, cluster in self.clusters.iteritems():
+    for cluster_index, cluster in self.clusters.items():
         cluster_list.append(cluster)
         cluster_indices.append(cluster_index)
         if cluster.number_of_members < self.minnpix_cluster:
@@ -1422,7 +1429,7 @@ def check_components_test(self, _cluster, _linked_clusters):
 def get_forest(self):
 
     _antecessors = []
-    for key, cluster in self.clusters.iteritems():
+    for key, cluster in self.clusters.items():
         if cluster.leaf_cluster == True:
             _antecessors.append(cluster.antecessor)
     _antecessors = remdup_preserve_order(_antecessors)
@@ -1447,11 +1454,11 @@ def print_to_terminal(self, count, unassigned_array_length, method, re=False):
 
     if (re==False):
 
-        print ''
-        print 'Beginning analysis...'
-        print ''
+        print('')
+        print('Beginning analysis...')
+        print('')
         print("leodis will look for clusters within {}% of the data: ".format((100 * unassigned_array_length / self.data[0,:].size)))
-        print ''
+        print('')
         print("Method = {}".format(method))
         print("Max. Euclidean distance between linked data = {}".format(np.around(self.max_dist, decimals = 2)))
         print("Min. # of data points in a cluster = {}".format(np.around(self.minnpix_cluster, decimals = 0)))
@@ -1460,26 +1467,26 @@ def print_to_terminal(self, count, unassigned_array_length, method, re=False):
 
         if self.method == 0:
             if len(self.cluster_criteria) != 1:
-                print ''
-                print "Additional criteria: "
+                print('')
+                print("Additional criteria: ")
                 for j in range(4, len(self.data[:,0])):
                     print("Max. absolute difference between column {} data = {}".format(j, np.around(self.cluster_criteria[j-3], decimals = 2)))
         if self.method == 1:
             print("Max. absolute velocity difference between linked data = {}".format(np.around(self.cluster_criteria[1], decimals = 2)))
-            print ''
+            print('')
             if len(self.cluster_criteria) > 2:
-                print "Additional criteria: "
+                print("Additional criteria: ")
                 for j in range(5, len(self.data[:,0])):
                     print("Max. absolute difference between column {} data = {}".format(j, np.around(self.cluster_criteria[j-3], decimals = 2)))
         if self.method == 2:
             if len(self.cluster_criteria) != 1:
-                print ''
-                print "Additional criteria: "
+                print('')
+                print("Additional criteria: ")
                 for j in range(4, len(self.data[:,0])):
                     print("Max. absolute difference between column {} data = {}".format(j, np.around(self.cluster_criteria[j-3], decimals = 2)))
 
-        print 'Primary clustering...'
-        print ''
+        print('Primary clustering...')
+        print('')
         progress_bar = AnimatedProgressBar(end=unassigned_array_length, width=50, \
                                            fill='=', blank='.')
 
@@ -1487,15 +1494,15 @@ def print_to_terminal(self, count, unassigned_array_length, method, re=False):
         relaxval = (100 * self.relax)
         if np.size(self.relax) == 1:
             print("Relaxing the linking constraints by {}%...".format(int(relaxval)))
-            print ''
-            print 'Secondary clustering...'
-            print ''
+            print('')
+            print('Secondary clustering...')
+            print('')
         else:
             for j in range(np.size(self.relax)):
                 print("Relaxing the linking constraint {} by {}%...".format(j+1, int(relaxval[j])))
-            print ''
-            print 'Secondary clustering...'
-            print ''
+            print('')
+            print('Secondary clustering...')
+            print('')
         progress_bar = AnimatedProgressBar(end=unassigned_array_length, width=50, \
                                            fill='=', blank='.')
 

--- a/leodis/leodis_io.py
+++ b/leodis/leodis_io.py
@@ -81,8 +81,8 @@ def output_fits(self, outputfile, extended=None, leodis_cols=None, headings=None
     """
     table = make_table(self, extended=extended, leodis_cols=leodis_cols, headings=headings )
     table.write(outputfile, format='fits', overwrite=True)
-    #print table
-    #print ""
+    #print(table)
+    #print("")
 
     return
 

--- a/leodis/progressbar.py
+++ b/leodis/progressbar.py
@@ -7,13 +7,13 @@ basic way.
 Here is some basic usage with the default options:
     >>> from progressbar import ProgressBar
     >>> p = ProgressBar()
-    >>> print p
+    >>> print(p)
     [>............] 0%
     >>> p + 1
-    >>> print p
+    >>> print(p)
     [=>...........] 10%
     >>> p + 9
-    >>> print p
+    >>> print(p)
     [============>] 0%
 And here another example with different options:
     >>> from progressbar import ProgressBar
@@ -24,13 +24,13 @@ And here another example with different options:
     ...     'format': '%(progress)s%% [%(fill)s%(blank)s]'
     ... }
     >>> p = ProgressBar(**custom_options)
-    >>> print p
+    >>> print(p)
     0% [....................]
     >>> p + 5
-    >>> print p
+    >>> print(p)
     5% [#...................]
     >>> p + 9
-    >>> print p
+    >>> print(p)
     100% [####################]
 Source: https://github.com/ikame/progressbar
 """

--- a/leodis/tree_definition.py
+++ b/leodis/tree_definition.py
@@ -327,7 +327,7 @@ def _dendrogram_positions(self):
             self._horizontals[0].append(np.array([np.min(np.asarray(x_loc_descendants)) ,np.min(np.asarray(x_loc_descendants))+range_x]))
             self._horizontals[1].append(np.array([self.tree_members[i].descendants[0].merge_level, self.tree_members[i].descendants[0].merge_level]))
 
-    #print self.horizontals
+    #print(self.horizontals)
     #sys.exit()
 
     return self


### PR DESCRIPTION
Got leodis working on Python 3! Tested the example script for both python 2 and 3, works like a charm. Here's a summary of changes:

1. As `print` has been made a function ([pep 3105](https://www.python.org/dev/peps/pep-3105/)), all the print statements now come in parentheses.
2. Replaced `iteritems` with `items` ([pep 469](http://legacy.python.org/dev/peps/pep-0469/)).
3. Comparing `None` to numeric types is no longer allowed, replaced None's with `-np.inf` in two lines.
4. Implicit relative imports within packages are banned since [pep 404](https://www.python.org/dev/peps/pep-0404/), fixed a few import statements.
5. xrange replaced with range, added backwards compatibility for python2 to still use `xrange`.